### PR TITLE
fix: fix urls in config

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -7,7 +7,7 @@ const darkCodeTheme = require("prism-react-renderer/themes/dracula");
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: "Write a JavaScript Parser in Rust",
-  url: "https://boshen.github.io",
+  url: "https://oxc-project.github.io",
   baseUrl: "/javascript-parser-in-rust/",
   onBrokenLinks: "throw",
   onBrokenMarkdownLinks: "throw",
@@ -26,14 +26,14 @@ const config = {
         docs: {
           sidebarPath: require.resolve("./sidebars.js"),
           editUrl:
-            "https://github.com/oxc-project/javascript-parser-in-rust/tree/main/docs",
+            "https://github.com/oxc-project/javascript-parser-in-rust/tree/main",
         },
         blog: {
           blogSidebarTitle: "Tutorials",
           blogSidebarCount: "ALL",
           sortPosts: "ascending",
           editUrl:
-            "https://github.com/oxc-project/javascript-parser-in-rust/tree/main/blog",
+            "https://github.com/oxc-project/javascript-parser-in-rust/tree/main",
           showReadingTime: true,
         },
         theme: {


### PR DESCRIPTION
No related issues.

The first bug was found during conversation with @ubugeeei and @kazupon on Twitter ([ref.](https://x.com/ubugeeei/status/1721194744582406557?s=20)).
Second one was found during fixing the first one.

- When sharing the website link, the domain is wrong and we get 404.
- When clicking the "edit this page" button, the links have redundant paths in their URL and we get 404.
  - e.g., https://github.com/oxc-project/javascript-parser-in-rust/tree/main/docs/docs/intro.md (see `docs` is duplicated)

To be honest, I'm not so familiar with Docusaurus, so I might be missing something important.