### PR TITLE
fix: rome.tools broken link

### DIFF
--- a/blog/rome.md
+++ b/blog/rome.md
@@ -9,7 +9,7 @@ This tutorial summarizes them in learning order for better understanding.
 
 ## History
 
-- The Rome codebase was rewritten from TypeScript to Rust, see [Rome will be rewritten in Rust](https://rome.tools/blog/2021/09/21/rome-will-be-rewritten-in-rust)
+- The Rome codebase was rewritten from TypeScript to Rust, see [Rome will be rewritten in Rust](https://web.archive.org/web/20230401084626/https://rome.tools/blog/2021/09/21/rome-will-be-rewritten-in-rust/)
 - The decision was made after talking to the author of [rslint](https://github.com/rslint/rslint) and [rust-analyzer](https://github.com/rust-lang/rust-analyzer)
 - rust-analyzer proved that IDE-centric tools built around concrete syntax tree are possible
 - rslint proved that it is possible to write a JavaScript parser in Rust, with the same base libraries as rust-analyzer

--- a/i18n/ja/docusaurus-plugin-content-blog/rome.md
+++ b/i18n/ja/docusaurus-plugin-content-blog/rome.md
@@ -8,7 +8,7 @@ Rome は、JavaScript と TypeScript のパースに様々な技術を使用し�
 
 ## 歴史
 
-- Rome のコードベースは TypeScript から Rust に書き直されました。詳細は [Rome will be rewritten in Rust](https://rome.tools/blog/2021/09/21/rome-will-be-rewritten-in-rust) をご覧ください。
+- Rome のコードベースは TypeScript から Rust に書き直されました。詳細は [Rome will be rewritten in Rust](https://web.archive.org/web/20230401084626/https://rome.tools/blog/2021/09/21/rome-will-be-rewritten-in-rust/) をご覧ください。
 - この決定は、[rslint](https://github.com/rslint/rslint) と [rust-analyzer](https://github.com/rust-lang/rust-analyzer) の作者との話し合いの結果行われました。
 - rust-analyzer は、IDE のようなツールを具象構文木をベースに構築できることを証明しました。
 - rslint は、rust-analyzer で使用されているライブラリを用いて、 Rust で JavaScript のパーサーを実装できることを証明しました。

--- a/i18n/ko/docusaurus-plugin-content-blog/rome.md
+++ b/i18n/ko/docusaurus-plugin-content-blog/rome.md
@@ -8,7 +8,7 @@ Rome은, JavaScript와 TypeScript 파서의 여러 기술을 사용합니다. �
 
 ## 역사
 
-- Rome 코드 기반은 TypeScript에서 Rust로 재작성되었습니다. 상세한 내용은 [Rome will be rewritten in Rust](https://rome.tools/blog/2021/09/21/rome-will-be-rewritten-in-rust) 를 통해 확인 가능합니다.
+- Rome 코드 기반은 TypeScript에서 Rust로 재작성되었습니다. 상세한 내용은 [Rome will be rewritten in Rust](https://web.archive.org/web/20230401084626/https://rome.tools/blog/2021/09/21/rome-will-be-rewritten-in-rust/) 를 통해 확인 가능합니다.
 - 이 결정은, [rslint](https://github.com/rslint/rslint)와 [rust-analyzer](https://github.com/rust-lang/rust-analyzer) 저자와 대화 후의 결과입니다.
 - rust-analyzer는, IDE 같은 도구를 추상 구문 트리 기반으로 구축하다는 것을 증명했습니다.
 - rslint는, rust-analyzer에 사용되어 있던 라이브러리를 사용해,  Rust에서 JavaScript 파서를 구현 가능하다는 것을 증명했습니다.

--- a/i18n/zh/docusaurus-plugin-content-blog/rome.md
+++ b/i18n/zh/docusaurus-plugin-content-blog/rome.md
@@ -9,7 +9,7 @@ This tutorial summarizes them in learning order for better understanding.
 
 ## History
 
-- The Rome codebase was rewritten from TypeScript to Rust, see [Rome will be rewritten in Rust](https://rome.tools/blog/2021/09/21/rome-will-be-rewritten-in-rust)
+- The Rome codebase was rewritten from TypeScript to Rust, see [Rome will be rewritten in Rust](https://web.archive.org/web/20230401084626/https://rome.tools/blog/2021/09/21/rome-will-be-rewritten-in-rust/)
 - The decision was made after talking to the author of [rslint](https://github.com/rslint/rslint) and [rust-analyzer](https://github.com/rust-lang/rust-analyzer)
 - rust-analyzer proved that IDE-centric tools built around concrete syntax tree are possible
 - rslint proved that it is possible to write a JavaScript parser in Rust, with the same base libraries as rust-analyzer


### PR DESCRIPTION
This is a fix related to https://github.com/oxc-project/javascript-parser-in-rust/issues/22. incorporated @suica's wise comments.
